### PR TITLE
Update and fix release workflows

### DIFF
--- a/.github/git-chglog/CHANGELOG.tpl.md
+++ b/.github/git-chglog/CHANGELOG.tpl.md
@@ -1,0 +1,28 @@
+{{ range .Versions }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+  {{ if .Body }}> {{ .Body }} {{ end }}
+  {{ end }}
+  {{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+
+{{ range .RevertCommits -}}
+* {{ .Revert.Header }}
+  {{ end }}
+  {{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.github/git-chglog/config.yml
+++ b/.github/git-chglog/config.yml
@@ -1,0 +1,32 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/sysdiglabs/terraform-google-secure
+options:
+  commits:
+  # filters:
+  #   Type:
+  #     - feat
+  #     - fix
+  #     - perf
+  #     - refactor
+  commit_groups:
+    title_maps:
+      feat: Features
+      fix: Bug Fixes
+      perf: Performance Improvements
+      refactor: Code Refactoring
+      ci: Continuous Integration
+      docs: Documentation
+      chore: Small Modifications
+      build: Compilation & Dependencies
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,35 +10,47 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Extract tag name
-      id: tag
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
 
-    - name: Create release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        draft: true
-        prerelease: false
-        body: |
-          This is the ${{ github.ref }} release of ${{ env.GITHUB_REPOSITORY }}
+      - name: Setup go-chglog
+        working-directory: /tmp
+        env:
+          VERSION: "0.10.0"
+        run: |
+          wget https://github.com/git-chglog/git-chglog/releases/download/v${VERSION}/git-chglog_${VERSION}_linux_amd64.tar.gz
+          gunzip git-chglog_${VERSION}_linux_amd64.tar.gz
+          tar -xvf git-chglog_${VERSION}_linux_amd64.tar
+          sudo mv git-chglog /usr/local/bin/
 
-          ### Major Changes
-          ### Minor Changes
-          ### Bug fixes
+      - name: Generate changelog
+        run: git-chglog -c .github/git-chglog/config.yml -o RELEASE_CHANGELOG.md $(git describe --tags $(git rev-list --tags --max-count=1))
 
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v1
-      with:
-        username: ${{ secrets.SYSDIGLABS_DOCKERHUB_USER }}
-        password: ${{ secrets.SYSDIGLABS_DOCKERHUB_TOKEN }}
-        repository: ${{ env.GITHUB_REPOSITORY }}
-        add_git_labels: true
-        dockerfile: build/Dockerfile
-        tags: latest, ${{ steps.tag.outputs.VERSION }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: false
+          body_path: RELEASE_CHANGELOG.md
+
+      # Check if we need to build using dockerfile in the release. If yes, uncomment below.
+      #- name: Build and push Docker image
+      #  uses: docker/build-push-action@v1
+      #  with:
+      #    username: ${{ secrets.SYSDIGLABS_DOCKERHUB_USER }}
+      #    password: ${{ secrets.SYSDIGLABS_DOCKERHUB_TOKEN }}
+      #    repository: ${{ env.GITHUB_REPOSITORY }}
+      #    add_git_labels: true
+      #    dockerfile: build/Dockerfile
+      #    tags: latest, ${{ steps.tag.outputs.VERSION }}


### PR DESCRIPTION
Change summary:
-----------------
1. Updated the release action to not run build & push docker image step using a `dockerfile`, since it doesn't seem to be required.
2. The changes are in parity with `terraform repo for AWS provider` and also the `terraform repo for GCP provider` running cloudbench based installs.