### PR TITLE
Implement Organizational CloudLogs module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Provides unified threat-detection, compliance, forensics and analysis through th
 
 * **[CSPM](https://docs.sysdig.com/en/docs/sysdig-secure/benchmarks/)**: It evaluates periodically your cloud configuration, using Cloud Custodian, against some benchmarks and returns the results and remediation you need to fix. Managed through `trust-relationship` module. <br/>
 
-* **CDR (Cloud Detection and Response)**: It send periodically the Audit Logs collected from a GCP project to Sysdig's systems, this by collecting them in a PubSub topic through a Sink and then sending them through a `PUSH` integration. Managed through `webhook-datasource` module. <br/>
+* **CDR (Cloud Detection and Response)**: It sends periodically the Audit Logs collected from a GCP project/organization to Sysdig's systems, this by collecting them in a PubSub topic through a Sink and then sending them through a `PUSH` integration. Managed through `webhook-datasource` module. <br/>
 
 For other Cloud providers check: [AWS](https://github.com/draios/terraform-aws-secure-for-cloud)
 

--- a/modules/services/webhook-datasource/README.md
+++ b/modules/services/webhook-datasource/README.md
@@ -40,6 +40,7 @@ No modules.
 | [google_pubsub_topic_iam_member.publisher_iam_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
 | [google_service_account.push_auth](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_binding.push_auth_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_organization.org](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/organization) | data source |
 
 ## Inputs
 
@@ -52,7 +53,7 @@ No modules.
 | <a name="input_maximum_backoff"></a> [maximum\_backoff](#input\_maximum\_backoff) | (Optional) Maximum backoff time for exponential backoff of the push subscription retry policy | `string` | `"600s"` | no |
 | <a name="input_message_retention_duration"></a> [message\_retention\_duration](#input\_message\_retention\_duration) | (Optional) How long unacknowledged messages are retained in Sysdig's subscription backlog, from the moment a message is published | `string` | `"604800s"` | no |
 | <a name="input_minimum_backoff"></a> [minimum\_backoff](#input\_minimum\_backoff) | (Optional) Minimum backoff time for exponential backoff of the push subscription retry policy | `string` | `"10s"` | no |
-| <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | (Optional) Your organization ID | `string` | n/a | yes |
+| <a name="input_organization_domain"></a> [organization\_domain](#input\_organization\_domain) | Organization domain. e.g. sysdig.com | `string` | `""` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | (Required) Target Project identifier provided by the customer | `string` | n/a | yes |
 | <a name="input_push_endpoint"></a> [push\_endpoint](#input\_push\_endpoint) | (Required) Final endpoint towards which audit logs POST calls will be directed | `string` | n/a | yes |
 

--- a/modules/services/webhook-datasource/README.md
+++ b/modules/services/webhook-datasource/README.md
@@ -1,13 +1,13 @@
 # GCP Webhook Datasource Module
 
-This Module creates the resources required to send Project-specific AuditLogs to Sysdig by creating a dedicated Push Subscription tied to a ingestion PubSub topic.
+This Module creates the resources required to send Project or Organization-specific AuditLogs to Sysdig by creating a dedicated Push Subscription tied to a ingestion PubSub topic.
 
 
 The following resources will be created in each instrumented account:
-- A Sink to direct the AuditLogs towards a dedicated PubSub topic
-- A PubSub ingestion topic that will hold all the AuditLogs coming from the specified project
-- A Push Subscription that will POST the AuditLogs collected from the project towards Sysdig's backend
-- All the necessary Service Accounts and Policies to enable the AuditLogs publishing operation
+- A Project/Organization `Sink` to direct the AuditLogs towards a dedicated PubSub topic
+- A `PubSub` ingestion topic that will hold all the AuditLogs coming from the specified project
+- A `Push` Subscription that will POST the AuditLogs collected from the project towards Sysdig's backend
+- All the necessary `Service Accounts` and `Policies` to enable the `AuditLogs` publishing operation
 
 ## Requirements
 
@@ -20,7 +20,7 @@ The following resources will be created in each instrumented account:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.21.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.0.0 |
 
 ## Modules
 
@@ -30,7 +30,9 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [google_logging_organization_sink.ingestion_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_organization_sink) | resource |
 | [google_logging_project_sink.ingestion_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
+| [google_organization_iam_audit_config.audit_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_audit_config) | resource |
 | [google_project_iam_audit_config.audit_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_audit_config) | resource |
 | [google_pubsub_subscription.ingestion_topic_push_subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_topic.deadletter_topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
@@ -44,11 +46,13 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ack_deadline_seconds"></a> [ack\_deadline\_seconds](#input\_ack\_deadline\_seconds) | (Optional) Maximum time in seconds after Sysdig's subscriber receives a message before the subscriber should acknowledge the message | `number` | `60` | no |
-| <a name="input_labels"></a> [labels](#input\_labels) | (Optional) Labels to be associated with Sysdig-originated resources | `map(string)` | <pre>{<br>  "originator": "Sysdig"<br>}</pre> | no |
+| <a name="input_is_organizational"></a> [is\_organizational](#input\_is\_organizational) | (Optional) Set this field to 'true' to deploy secure-for-cloud to a GCP Organization. | `bool` | `false` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | (Optional) Labels to be associated with Sysdig-originated resources | `map(string)` | <pre>{<br>  "originator": "sysdig"<br>}</pre> | no |
 | <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | (Optional) Number of attempts redelivering missed messages from the deadletter topic to the main one | `number` | `5` | no |
 | <a name="input_maximum_backoff"></a> [maximum\_backoff](#input\_maximum\_backoff) | (Optional) Maximum backoff time for exponential backoff of the push subscription retry policy | `string` | `"600s"` | no |
 | <a name="input_message_retention_duration"></a> [message\_retention\_duration](#input\_message\_retention\_duration) | (Optional) How long unacknowledged messages are retained in Sysdig's subscription backlog, from the moment a message is published | `string` | `"604800s"` | no |
 | <a name="input_minimum_backoff"></a> [minimum\_backoff](#input\_minimum\_backoff) | (Optional) Minimum backoff time for exponential backoff of the push subscription retry policy | `string` | `"10s"` | no |
+| <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | (Optional) Your organization ID | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | (Required) Target Project identifier provided by the customer | `string` | n/a | yes |
 | <a name="input_push_endpoint"></a> [push\_endpoint](#input\_push\_endpoint) | (Required) Final endpoint towards which audit logs POST calls will be directed | `string` | n/a | yes |
 
@@ -56,6 +60,4 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | GCP Project Identifier |
 | <a name="output_push_endpoint"></a> [push\_endpoint](#output\_push\_endpoint) | Push endpoint towards which the POST request will be directed |
-| <a name="output_push_subscription_service_account"></a> [push\_subscription\_service\_account](#output\_push\_subscription\_service\_account) | Service Account used to send POST messages, a KMS key needs to be manually added in order to properly authenticate the requests at Sysdig's side |

--- a/modules/services/webhook-datasource/main.tf
+++ b/modules/services/webhook-datasource/main.tf
@@ -16,6 +16,11 @@
 # Subscription that will send the data to Sysdig's backend. This module takes also care
 # of creating the necessary service accounts along with the necessary policies to enable
 # pushing logs to Sysdig's system.
+#
+# Note: The alternative definitions for the organizational variant of this module are contained
+# in organizational.tf. The only differences w.r.t. the standalone template is in using an
+# organizational sink instead of a project-specific one, as well as enabling AuditLogs for
+# all the projects that fall within the organization.
 ########################################################################################
 
 #-------------#

--- a/modules/services/webhook-datasource/main.tf
+++ b/modules/services/webhook-datasource/main.tf
@@ -23,14 +23,6 @@
 # all the projects that fall within the organization.
 ########################################################################################
 
-#-------------#
-# GCP Project #
-#-------------#
-
-data "google_project" "target_project" {
-  project_id = var.project_id
-}
-
 #------------#
 # Audit Logs #
 #------------#

--- a/modules/services/webhook-datasource/main.tf
+++ b/modules/services/webhook-datasource/main.tf
@@ -49,6 +49,25 @@ resource "google_project_iam_audit_config" "audit_config" {
   }
 }
 
+resource "google_organization_iam_audit_config" "audit_config" {
+  count = var.is_organizational ? 1 : 0
+
+  org_id  = var.organization_id
+  service = "allServices"
+
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+
+  audit_log_config {
+    log_type = "DATA_WRITE"
+  }
+}
+
 #-----------------#
 # Ingestion topic #
 #-----------------#
@@ -97,10 +116,8 @@ resource "google_logging_organization_sink" "ingestion_sink" {
   destination = "pubsub.googleapis.com/projects/${var.project_id}/topics/${google_pubsub_topic.ingestion_topic.name}"
   filter      = "protoPayload.@type = \"type.googleapis.com/google.cloud.audit.AuditLog\""
 
-  # TODO(jojo): do we need this?
-  disabled = false
-
-  # TODO(jojo): do we need this?
+  # NOTE: The include_children attribute is set to true in order to ingest data
+  # even from potential sub-organizations
   include_children = true
 }
 

--- a/modules/services/webhook-datasource/main.tf
+++ b/modules/services/webhook-datasource/main.tf
@@ -49,25 +49,6 @@ resource "google_project_iam_audit_config" "audit_config" {
   }
 }
 
-resource "google_organization_iam_audit_config" "audit_config" {
-  count = var.is_organizational ? 1 : 0
-
-  org_id  = var.organization_id
-  service = "allServices"
-
-  audit_log_config {
-    log_type = "ADMIN_READ"
-  }
-
-  audit_log_config {
-    log_type = "DATA_READ"
-  }
-
-  audit_log_config {
-    log_type = "DATA_WRITE"
-  }
-}
-
 #-----------------#
 # Ingestion topic #
 #-----------------#
@@ -105,28 +86,11 @@ resource "google_logging_project_sink" "ingestion_sink" {
   unique_writer_identity = true
 }
 
-resource "google_logging_organization_sink" "ingestion_sink" {
-  count = var.is_organizational ? 1 : 0
-
-  name        = "${google_pubsub_topic.ingestion_topic.name}_sink"
-  description = "Sysdig sink to direct the AuditLogs to the PubSub topic used for data gathering"
-  org_id      = var.organization_id
-
-  # NOTE: The target destination is a PubSub topic
-  destination = "pubsub.googleapis.com/projects/${var.project_id}/topics/${google_pubsub_topic.ingestion_topic.name}"
-  filter      = "protoPayload.@type = \"type.googleapis.com/google.cloud.audit.AuditLog\""
-
-  # NOTE: The include_children attribute is set to true in order to ingest data
-  # even from potential sub-organizations
-  include_children = true
-}
-
 resource "google_pubsub_topic_iam_member" "publisher_iam_member" {
   project = google_pubsub_topic.ingestion_topic.project
   topic   = google_pubsub_topic.ingestion_topic.name
   role    = "roles/pubsub.publisher"
-  # member  = google_logging_project_sink.ingestion_sink.writer_identity
-  member = var.is_organizational ? google_logging_organization_sink.ingestion_sink[0].writer_identity : google_logging_project_sink.ingestion_sink[0].writer_identity
+  member  = var.is_organizational ? google_logging_organization_sink.ingestion_sink[0].writer_identity : google_logging_project_sink.ingestion_sink[0].writer_identity
 }
 
 #-------------------#

--- a/modules/services/webhook-datasource/organizational.tf
+++ b/modules/services/webhook-datasource/organizational.tf
@@ -1,11 +1,19 @@
+#--------------#
+# Organization #
+#--------------#
+
+data "google_organization" "org" {
+  count  = var.is_organizational ? 1 : 0
+  domain = var.organization_domain
+}
+
 #------------#
 # Audit Logs #
 #------------#
-
 resource "google_organization_iam_audit_config" "audit_config" {
   count = var.is_organizational ? 1 : 0
 
-  org_id  = var.organization_id
+  org_id  = data.google_organization.org[0].org_id
   service = "allServices"
 
   audit_log_config {
@@ -30,7 +38,7 @@ resource "google_logging_organization_sink" "ingestion_sink" {
 
   name        = "${google_pubsub_topic.ingestion_topic.name}_sink"
   description = "Sysdig sink to direct the AuditLogs to the PubSub topic used for data gathering"
-  org_id      = var.organization_id
+  org_id      = data.google_organization.org[0].org_id
 
   # NOTE: The target destination is a PubSub topic
   destination = "pubsub.googleapis.com/projects/${var.project_id}/topics/${google_pubsub_topic.ingestion_topic.name}"

--- a/modules/services/webhook-datasource/organizational.tf
+++ b/modules/services/webhook-datasource/organizational.tf
@@ -1,0 +1,42 @@
+#------------#
+# Audit Logs #
+#------------#
+
+resource "google_organization_iam_audit_config" "audit_config" {
+  count = var.is_organizational ? 1 : 0
+
+  org_id  = var.organization_id
+  service = "allServices"
+
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+
+  audit_log_config {
+    log_type = "DATA_WRITE"
+  }
+}
+
+#------#
+# Sink #
+#------#
+
+resource "google_logging_organization_sink" "ingestion_sink" {
+  count = var.is_organizational ? 1 : 0
+
+  name        = "${google_pubsub_topic.ingestion_topic.name}_sink"
+  description = "Sysdig sink to direct the AuditLogs to the PubSub topic used for data gathering"
+  org_id      = var.organization_id
+
+  # NOTE: The target destination is a PubSub topic
+  destination = "pubsub.googleapis.com/projects/${var.project_id}/topics/${google_pubsub_topic.ingestion_topic.name}"
+  filter      = "protoPayload.@type = \"type.googleapis.com/google.cloud.audit.AuditLog\""
+
+  # NOTE: The include_children attribute is set to true in order to ingest data
+  # even from potential sub-organizations
+  include_children = true
+}

--- a/modules/services/webhook-datasource/outputs.tf
+++ b/modules/services/webhook-datasource/outputs.tf
@@ -1,13 +1,3 @@
-output "project_id" {
-  value       = data.google_project.target_project.id
-  description = "GCP Project Identifier"
-}
-
-output "push_subscription_service_account" {
-  value       = google_service_account.push_auth.name
-  description = "Service Account used to send POST messages, a KMS key needs to be manually added in order to properly authenticate the requests at Sysdig's side"
-}
-
 output "push_endpoint" {
   value       = google_pubsub_subscription.ingestion_topic_push_subscription.push_config[0].push_endpoint
   description = "Push endpoint towards which the POST request will be directed"

--- a/modules/services/webhook-datasource/variables.tf
+++ b/modules/services/webhook-datasource/variables.tf
@@ -45,3 +45,14 @@ variable "maximum_backoff" {
   description = "(Optional) Maximum backoff time for exponential backoff of the push subscription retry policy"
   default     = "600s"
 }
+
+variable "is_organizational" {
+  description = "(Optional) Set this field to 'true' to deploy secure-for-cloud to a GCP Organization."
+  type        = bool
+  default     = false
+}
+
+variable "organization_id" {
+  description = "(Optional) Your organization ID"
+  type        = string
+}

--- a/modules/services/webhook-datasource/variables.tf
+++ b/modules/services/webhook-datasource/variables.tf
@@ -52,7 +52,8 @@ variable "is_organizational" {
   default     = false
 }
 
-variable "organization_id" {
-  description = "(Optional) Your organization ID"
+variable "organization_domain" {
   type        = string
+  description = "(Optional) Organization domain. e.g. sysdig.com"
+  default     = ""
 }


### PR DESCRIPTION
In this PR we introduce the organizational part of the `CloudLogs` module. The changes have been organized between `main.tf` and `organizational.tf` as per previous convention. The only difference among the single and organizational cases is in using an organizational sink to direct the `AuditLogs` coming from all the projects contained within the organization to the same `PubSub` topic. 

Note for the reviewer: The organizational variant still requires a `project_id` as the input parameter, since the resources cannot be declared at organization level. The module will work regardless of the project chosen by the user, after a talk with @nkraemer-sysdig we decided to let them choose where to place the required resources