### PR TITLE
(internal) Delay SA roles and key resource creation

### DIFF
--- a/modules/services/service-principal/main.tf
+++ b/modules/services/service-principal/main.tf
@@ -17,7 +17,7 @@ resource "null_resource" "delay" {
     command = "sleep 15"
   }
   triggers = {
-    "sa" = "${google_service_account.sa.id}"
+    sa = google_service_account.sa.id
   }
 }
 

--- a/modules/services/service-principal/organizational.tf
+++ b/modules/services/service-principal/organizational.tf
@@ -15,7 +15,8 @@ data "google_organization" "org" {
 # role permissions for onboarding
 #---------------------------------
 resource "google_organization_iam_member" "browser" {
-  count = var.is_organizational ? 1 : 0
+  depends_on = [null_resource.delay]
+  count      = var.is_organizational ? 1 : 0
 
   org_id = data.google_organization.org[0].org_id
   role   = "roles/browser"
@@ -26,7 +27,8 @@ resource "google_organization_iam_member" "browser" {
 # role permissions for CSPM (GCP Predefined Roles for Sysdig Cloud Secure Posture Management)
 #---------------------------------------------------------------------------------------------
 resource "google_organization_iam_member" "cspm" {
-  for_each = var.is_organizational ? toset(["roles/cloudasset.viewer", "roles/iam.serviceAccountTokenCreator", "roles/logging.viewer"]) : []
+  depends_on = [null_resource.delay]
+  for_each   = var.is_organizational ? toset(["roles/cloudasset.viewer", "roles/iam.serviceAccountTokenCreator", "roles/logging.viewer"]) : []
 
   org_id = data.google_organization.org[0].org_id
   role   = each.key
@@ -37,7 +39,8 @@ resource "google_organization_iam_member" "cspm" {
 # role permissions for CIEM (GCP Predefined Roles for Sysdig Cloud Identity Management)
 #---------------------------------------------------------------------------------------
 resource "google_organization_iam_member" "identity_mgmt" {
-  for_each = var.is_organizational ? toset(["roles/recommender.viewer", "roles/iam.serviceAccountViewer", "roles/iam.organizationRoleViewer", "roles/container.clusterViewer", "roles/compute.viewer"]) : []
+  depends_on = [null_resource.delay]
+  for_each   = var.is_organizational ? toset(["roles/recommender.viewer", "roles/iam.serviceAccountViewer", "roles/iam.organizationRoleViewer", "roles/container.clusterViewer", "roles/compute.viewer"]) : []
 
   org_id = data.google_organization.org[0].org_id
   role   = each.key

--- a/modules/services/service-principal/versions.tf
+++ b/modules/services/service-principal/versions.tf
@@ -7,4 +7,10 @@ terraform {
       version = ">= 4.21.0"
     }
   }
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.1"
+    }
+  }
 }

--- a/modules/services/service-principal/versions.tf
+++ b/modules/services/service-principal/versions.tf
@@ -6,8 +6,6 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 4.21.0"
     }
-  }
-  required_providers {
     null = {
       source  = "hashicorp/null"
       version = ">= 3.2.1"


### PR DESCRIPTION
Change summary:
--------------------
Delaying the resources for IAM roles assignment and key creation till the GCP Service account is created. This is to ensure the SA is ready for consumption since its creation is eventually consistent.

Tested using TF multiple times to ensure we don't run into 403s from googleapis when GCP takes time to have the SA ready for consumption.