### PR TITLE
(internal) Add validation test coverage

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -33,6 +33,13 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example:
+          - "secure_config_posture_identity_access/single/main.tf"
+          - "secure_config_posture_identity_access/organization/main.tf"
+          - "secure_threat_detection/single/main.tf"
+          - "secure_threat_detection/organization/main.tf"
     steps:
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -54,4 +61,6 @@ jobs:
     # - name: Build
     #   run: go build ./...
     - name: Test
+      env:
+        EXAMPLES: examples/${{ matrix.example }}
       run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+.idea
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+terraform.tfvars
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+.terraform.lock.hcl
+.envrc
+**/.envrc
+
+*.patch
+
+# MacOS
+.DS_Store

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,2 +1,2 @@
 test:
-	@echo "Functional Tests to be added here."
+	./functional.sh

--- a/test/examples/secure_config_posture_identity_access/organization/main.tf
+++ b/test/examples/secure_config_posture_identity_access/organization/main.tf
@@ -1,0 +1,71 @@
+provider "google" {
+  project = "mytestproject"
+  region  = "us-west1"
+}
+
+module "organization-posture" {
+  source               = "../../../..//modules/services/service-principal"
+  project_id           = "mytestproject"
+  service_account_name = "sysdig-secure"
+  is_organizational    = true
+  organization_domain  = "mytestorg.com"
+}
+
+terraform {
+
+  required_providers {
+    sysdig = {
+      source  = "sysdiglabs/sysdig"
+      version = "~> 1.18.2"
+    }
+  }
+}
+
+provider "sysdig" {
+  sysdig_secure_url       = "test_sysdig_secure_endpoint"
+  sysdig_secure_api_token = "test_sysdig_secure_api_token"
+}
+
+resource "sysdig_secure_cloud_auth_account" "gcp_project_mytestproject" {
+  enabled       = true
+  provider_id   = "mytestproject"
+  provider_type = "PROVIDER_GCP"
+
+  feature {
+
+    secure_identity_entitlement {
+      enabled    = true
+      components = ["COMPONENT_SERVICE_PRINCIPAL/secure-posture"]
+    }
+
+    secure_config_posture {
+      enabled    = true
+      components = ["COMPONENT_SERVICE_PRINCIPAL/secure-posture"]
+    }
+  }
+  component {
+    type     = "COMPONENT_SERVICE_PRINCIPAL"
+    instance = "secure-posture"
+    service_principal_metadata = jsonencode({
+      gcp = {
+        key = module.organization-posture.service_account_key
+      }
+    })
+  }
+  component {
+    type     = "COMPONENT_SERVICE_PRINCIPAL"
+    instance = "secure-onboarding"
+    service_principal_metadata = jsonencode({
+      gcp = {
+        key = module.organization-posture.service_account_key
+      }
+    })
+  }
+  depends_on = [module.organization-posture]
+}
+
+resource "sysdig_secure_organization" "gcp_organization_mytestproject" {
+  management_account_id = sysdig_secure_cloud_auth_account.gcp_project_mytestproject.id
+  depends_on            = [module.organization-posture]
+}
+

--- a/test/examples/secure_config_posture_identity_access/single/main.tf
+++ b/test/examples/secure_config_posture_identity_access/single/main.tf
@@ -1,0 +1,54 @@
+provider "google" {
+  project = "mytestproject"
+  region  = "us-west1"
+}
+
+module "project-posture" {
+  source               = "../../../..//modules/services/service-principal"
+  project_id           = "mytestproject"
+  service_account_name = "sysdig-secure"
+}
+
+terraform {
+
+  required_providers {
+    sysdig = {
+      source  = "sysdiglabs/sysdig"
+      version = "~> 1.18.2"
+    }
+  }
+}
+
+provider "sysdig" {
+  sysdig_secure_url       = "test_sysdig_secure_endpoint"
+  sysdig_secure_api_token = "test_sysdig_secure_api_token"
+}
+
+resource "sysdig_secure_cloud_auth_account" "gcp_project_mytestproject" {
+  enabled       = true
+  provider_id   = "mytestproject"
+  provider_type = "PROVIDER_GCP"
+
+  feature {
+
+    secure_identity_entitlement {
+      enabled    = true
+      components = ["COMPONENT_SERVICE_PRINCIPAL/secure-posture"]
+    }
+
+    secure_config_posture {
+      enabled    = true
+      components = ["COMPONENT_SERVICE_PRINCIPAL/secure-posture"]
+    }
+  }
+  component {
+    type     = "COMPONENT_SERVICE_PRINCIPAL"
+    instance = "secure-posture"
+    service_principal_metadata = jsonencode({
+      gcp = {
+        key = module.project-posture.service_account_key
+      }
+    })
+  }
+  depends_on = [module.project-posture]
+}

--- a/test/examples/secure_threat_detection/organization/main.tf
+++ b/test/examples/secure_threat_detection/organization/main.tf
@@ -1,0 +1,68 @@
+provider "google" {
+  project = "mytestproject"
+  region  = "us-west1"
+}
+
+module "organization-threat-detection" {
+  source            	= "../../../..//modules/services/webhook-datasource"
+  project_id        	= "mytestproject"
+  push_endpoint     	= "test_sysdig_secure_cloudingestion_endpoint"
+  is_organizational 	= true
+  organization_domain = "mytestorg.com"
+}
+
+module "organization-posture" {
+  source               = "../../../..//modules/services/service-principal"
+  project_id           = "mytestproject"
+  service_account_name = "sysdig-secure"
+  is_organizational    = true
+  organization_domain  = "mytestorg.com"
+}
+
+terraform {
+
+  required_providers {
+    sysdig = {
+      source  = "sysdiglabs/sysdig"
+      version = "~> 1.18.2"
+    }
+  }
+}
+
+provider "sysdig" {
+  sysdig_secure_url       = "test_sysdig_secure_endpoint"
+  sysdig_secure_api_token = "test_sysdig_secure_api_token"
+}
+
+resource "sysdig_secure_cloud_auth_account" "gcp_project_mytestproject" {
+  enabled       = true
+  provider_id   = "mytestproject"
+  provider_type = "PROVIDER_GCP"
+
+  feature {
+
+    secure_threat_detection {
+      enabled    = true
+      components = ["COMPONENT_WEBHOOK_DATASOURCE/secure-runtime"]
+    }
+  }
+  component {
+    type     = "COMPONENT_WEBHOOK_DATASOURCE"
+    instance = "secure-runtime"
+  }
+  component {
+    type     = "COMPONENT_SERVICE_PRINCIPAL"
+    instance = "secure-onboarding"
+    service_principal_metadata = jsonencode({
+      gcp = {
+        key = module.organization-posture.service_account_key
+      }
+    })
+  }
+}
+
+resource "sysdig_secure_organization" "gcp_organization_mytestproject" {
+  management_account_id = sysdig_secure_cloud_auth_account.gcp_project_mytestproject.id
+  depends_on            = [module.organization-posture]
+}
+

--- a/test/examples/secure_threat_detection/single/main.tf
+++ b/test/examples/secure_threat_detection/single/main.tf
@@ -1,0 +1,44 @@
+provider "google" {
+  project = "mytestproject"
+  region  = "us-west1"
+}
+
+module "single-project-threat-detection" {
+  source        = "../../../..//modules/services/webhook-datasource"
+  project_id    = "mytestproject"
+  push_endpoint = "test_sysdig_secure_cloudingestion_endpoint"
+}
+
+terraform {
+
+  required_providers {
+    sysdig = {
+      source  = "sysdiglabs/sysdig"
+      version = "~> 1.18.2"
+    }
+  }
+}
+
+provider "sysdig" {
+  sysdig_secure_url       = "test_sysdig_secure_endpoint"
+  sysdig_secure_api_token = "test_sysdig_secure_api_token"
+}
+
+resource "sysdig_secure_cloud_auth_account" "gcp_project_mytestproject" {
+  enabled       = true
+  provider_id   = "mytestproject"
+  provider_type = "PROVIDER_GCP"
+
+  feature {
+
+    secure_threat_detection {
+      enabled    = true
+      components = ["COMPONENT_WEBHOOK_DATASOURCE/secure-runtime"]
+    }
+  }
+  component {
+    type     = "COMPONENT_WEBHOOK_DATASOURCE"
+    instance = "secure-runtime"
+  }
+}
+

--- a/test/functional.sh
+++ b/test/functional.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+test -n "${EXAMPLES}" || EXAMPLES=$(find examples -type f -name main.tf)
+
+for example in ${EXAMPLES} ; do
+  printf "Functional testing - ${example}\n"
+  example_dir="$(dirname ${example})"
+  test -d "${example_dir}" || (printf "not an example directory: ${example_dir}\n" ; exit 1)
+  pushd "${example_dir}"
+    # run
+    terraform init
+    terraform validate
+
+    # cleanup (except configuration file)
+    git clean -fxde main.tf
+  popd
+done


### PR DESCRIPTION
Coverage summary:
----------------------
- Added validation test coverage for SP module used by Posture & Identity Access
- Added validation test coverage for webhook module used by Threat detection
- Keeping the test structure in parity with other cloud providers repo (e.g AWS)
- Added gitignore

Note: while this may not give us the full overage we need, its a start rather than having no coverage at all.