### PR TITLE
[SSPROD-40621] Adding necessary view only permissions for GCP CSPM in order to Agentless Serverless scanning

### DIFF
--- a/modules/services/service-principal/main.tf
+++ b/modules/services/service-principal/main.tf
@@ -23,7 +23,7 @@ resource "google_project_iam_member" "browser" {
 # role permissions for CSPM (GCP Predefined Roles for Sysdig Cloud Secure Posture Management)
 #---------------------------------------------------------------------------------------------
 resource "google_project_iam_member" "cspm" {
-  for_each = var.is_organizational ? [] : toset(["roles/cloudasset.viewer", "roles/iam.serviceAccountTokenCreator", "roles/logging.viewer"])
+  for_each = var.is_organizational ? [] : toset(["roles/cloudasset.viewer", "roles/iam.serviceAccountTokenCreator", "roles/logging.viewer", "roles/cloudfunctions.viewer", "roles/cloudbuild.builds.viewer"])
 
   project = var.project_id
   role    = each.key

--- a/modules/services/service-principal/organizational.tf
+++ b/modules/services/service-principal/organizational.tf
@@ -26,7 +26,7 @@ resource "google_organization_iam_member" "browser" {
 # role permissions for CSPM (GCP Predefined Roles for Sysdig Cloud Secure Posture Management)
 #---------------------------------------------------------------------------------------------
 resource "google_organization_iam_member" "cspm" {
-  for_each = var.is_organizational ? toset(["roles/cloudasset.viewer", "roles/iam.serviceAccountTokenCreator", "roles/logging.viewer"]) : []
+  for_each = var.is_organizational ? toset(["roles/cloudasset.viewer", "roles/iam.serviceAccountTokenCreator", "roles/logging.viewer", "roles/cloudfunctions.viewer", "roles/cloudbuild.builds.viewer"]) : []
 
   org_id = data.google_organization.org[0].org_id
   role   = each.key


### PR DESCRIPTION
This PR adds the cloudfunction.viewer and cloudbuilders.builds.viewer roles to the base CSPM GCP onboarding on both org and single mode.

This is required to enable Agentless Google Cloud Function Scanning, since:
1. We will list all the cloud functions on a customers project
2. From the functions retrieved, we will scrape their last docker image build

From the information gathered, agentless serverless scanning will be enabled by scanning the retrieved docker image built for the GCP Cloud Function.