### PR TITLE
[SSPROD-4000] Adding missing permissions to Workload Scanning to make it work with GCR docker images

### DIFF
--- a/modules/services/workload-scan/controller.tf
+++ b/modules/services/workload-scan/controller.tf
@@ -15,6 +15,9 @@ resource "google_project_iam_custom_role" "controller" {
     "artifactregistry.repositories.list",
     "artifactregistry.dockerimages.get",
     "artifactregistry.dockerimages.list",
+    "storage.objects.get",
+    "storage.buckets.list",
+    "storage.objects.list",
 
     # workload identity federation
     "iam.serviceAccounts.getAccessToken",


### PR DESCRIPTION
Workload Scanning was not scanning GCR images due to lack of onboarding permissions to storage.buckets.