### PR TITLE
feat(modular): add TF snippets for enable GCP APIs

### DIFF
--- a/test/examples/organization_api_enablement/cdr_ciem/main.tf
+++ b/test/examples/organization_api_enablement/cdr_ciem/main.tf
@@ -1,0 +1,53 @@
+/*
+This terraform file is intended to enable the GCP APIs needed for CDR/CIEM feature within a GCP organization onboarding.
+It will create a google_project_service resource per each service enabled within each GCP project.
+The APIs needed for the CDR/CIEM feature are listed below:
+  - Cloud Pub/Sub API
+
+* Note: This do not overwrite any other APIs config that your GCP project has, it will only enabled it if isn't yet.
+*/
+
+# Set local variables for Organization ID and API services to enable
+locals {
+  organizationID = "933620940614"
+  services = [
+    "pubsub.googleapis.com"
+  ]
+  project_and_services = flatten([
+    for project in data.google_projects.organization_projects.projects : [
+      for service in local.services : {
+        project = project.project_id
+        service = service
+      }
+    ]
+  ])
+}
+
+# GCP provider
+provider "google" {
+  region      = "us-west-1"
+}
+
+# Get list of projects under the specified organization
+data "google_projects" "organization_projects" {
+  filter = "parent.type:organization parent.id:${local.organizationID}"
+}
+
+# Enable API services for GCP project
+resource "google_project_service" "enable_cdr_ciem_apis" {
+  // create a unique key per project and service to enable each API
+  for_each = { for item in local.project_and_services : "${item.project}-${item.service}" => item }
+
+  project = each.value.project
+  service = each.value.service
+  disable_on_destroy = false
+}
+
+# Output the projects and APIs enabled
+output "enabled_projects" {
+  value = distinct([for resource in google_project_service.enable_cdr_ciem_apis : resource.project])
+}
+
+output "enabled_services" {
+  value = distinct([for service in google_project_service.enable_cdr_ciem_apis : service.service])
+}

--- a/test/examples/organization_api_enablement/cspm/main.tf
+++ b/test/examples/organization_api_enablement/cspm/main.tf
@@ -1,0 +1,66 @@
+# /*
+# This terraform file is intended to enable the GCP APIs needed for CSPM feature within an organization onboarding.
+# It will create a google_project_service resource per each service enabled within each GCP project.
+# The APIs needed for the CSPM feature are listed below:
+#   - Security Token Service API
+#   - Cloud Asset API
+#   - Cloud Identity API
+#   - Admin SDK API
+# In addition, since CSPM is needed for onboard any GCP project these other APIs are also enabled:
+#   - Identity and access management API
+#   - IAM Service Account Credentials API
+#   - Cloud Resource Manager API
+#
+# * Note: This do not overwrite any other APIs config that your GCP project has, it will only enabled it if isn't yet.
+# */
+#
+# # Set local variables for Organization ID and API services to enable
+# locals {
+#   organization = "933620940614"
+#   services = [
+#     # CSPM specific APIs
+#     "sts.googleapis.com",
+#     "cloudasset.googleapis.com",
+#     "cloudidentity.googleapis.com",
+#     "admin.googleapis.com",
+#
+#     # additional APIs
+#     "iam.googleapis.com",
+#     "iamcredentials.googleapis.com",
+#     "cloudresourcemanager.googleapis.com"
+#   ]
+# }
+#
+# # GCP provider
+# provider "google" {
+# #   project     = local.project
+#   region      = "us-west-1"
+# }
+#
+# # Get list of projects under the specified organization
+# data "google_projects" "organization_projects" {
+# #   filter = "parent.type:organization parent.id:${local.organization}"
+# }
+#
+# output "org_projects" {
+#   value = data.google_projects.organization_projects
+# }
+#
+#
+# # // Enable API services for GCP project
+# # resource "google_project_service" "enable_cdr_ciem_apis" {
+# #   project  = local.project
+# #
+# #   for_each = toset(local.services)
+# #   service = each.value
+# #   # TODO: Question? Leave a note to user that APIs will keep enabled when running a TF destroy here, makes sense?
+# #   disable_on_destroy = false
+# # }
+# #
+# # # Output the projects and APIs enabled
+# # output "enabled_projects" {
+# #   value = distinct([for service in local.services : google_project_service.enable_cdr_ciem_apis[service].project])
+# # }
+# # output "enabled_services" {
+# #   value = [for service in local.services : google_project_service.enable_cdr_ciem_apis[service].service]
+# # }

--- a/test/examples/organization_api_enablement/cspm/main.tf
+++ b/test/examples/organization_api_enablement/cspm/main.tf
@@ -1,66 +1,69 @@
-# /*
-# This terraform file is intended to enable the GCP APIs needed for CSPM feature within an organization onboarding.
-# It will create a google_project_service resource per each service enabled within each GCP project.
-# The APIs needed for the CSPM feature are listed below:
-#   - Security Token Service API
-#   - Cloud Asset API
-#   - Cloud Identity API
-#   - Admin SDK API
-# In addition, since CSPM is needed for onboard any GCP project these other APIs are also enabled:
-#   - Identity and access management API
-#   - IAM Service Account Credentials API
-#   - Cloud Resource Manager API
-#
-# * Note: This do not overwrite any other APIs config that your GCP project has, it will only enabled it if isn't yet.
-# */
-#
-# # Set local variables for Organization ID and API services to enable
-# locals {
-#   organization = "933620940614"
-#   services = [
-#     # CSPM specific APIs
-#     "sts.googleapis.com",
-#     "cloudasset.googleapis.com",
-#     "cloudidentity.googleapis.com",
-#     "admin.googleapis.com",
-#
-#     # additional APIs
-#     "iam.googleapis.com",
-#     "iamcredentials.googleapis.com",
-#     "cloudresourcemanager.googleapis.com"
-#   ]
-# }
-#
-# # GCP provider
-# provider "google" {
-# #   project     = local.project
-#   region      = "us-west-1"
-# }
-#
-# # Get list of projects under the specified organization
-# data "google_projects" "organization_projects" {
-# #   filter = "parent.type:organization parent.id:${local.organization}"
-# }
-#
-# output "org_projects" {
-#   value = data.google_projects.organization_projects
-# }
-#
-#
-# # // Enable API services for GCP project
-# # resource "google_project_service" "enable_cdr_ciem_apis" {
-# #   project  = local.project
-# #
-# #   for_each = toset(local.services)
-# #   service = each.value
-# #   # TODO: Question? Leave a note to user that APIs will keep enabled when running a TF destroy here, makes sense?
-# #   disable_on_destroy = false
-# # }
-# #
-# # # Output the projects and APIs enabled
-# # output "enabled_projects" {
-# #   value = distinct([for service in local.services : google_project_service.enable_cdr_ciem_apis[service].project])
-# # }
-# # output "enabled_services" {
-# #   value = [for service in local.services : google_project_service.enable_cdr_ciem_apis[service].service]
-# # }
+/*
+This terraform file is intended to enable the GCP APIs needed for CSPM feature within a GCP organization onboarding.
+It will create a google_project_service resource per each service enabled within each GCP project.
+The APIs needed for the CSPM feature are listed below:
+  - Security Token Service API
+  - Cloud Asset API
+  - Cloud Identity API
+  - Admin SDK API
+In addition, since CSPM is needed for onboard any GCP project these other APIs are also enabled:
+  - Identity and access management API
+  - IAM Service Account Credentials API
+  - Cloud Resource Manager API
+
+* Note: This do not overwrite any other APIs config that your GCP project has, it will only enabled it if isn't yet.
+*/
+
+# Set local variables for Organization ID and API services to enable
+locals {
+  organizationID = "933620940614"
+  services = [
+    # CSPM specific APIs
+    "sts.googleapis.com",
+    "cloudasset.googleapis.com",
+    "cloudidentity.googleapis.com",
+    "admin.googleapis.com",
+
+    # additional APIs
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "cloudresourcemanager.googleapis.com"
+  ]
+  project_and_services = flatten([
+    for project in data.google_projects.organization_projects.projects : [
+      for service in local.services : {
+        project = project.project_id
+        service = service
+      }
+    ]
+  ])
+}
+
+# GCP provider
+provider "google" {
+  region      = "us-west-1"
+}
+
+# Get list of projects under the specified organization
+data "google_projects" "organization_projects" {
+   filter = "parent.type:organization parent.id:${local.organizationID}"
+}
+
+# Enable API services for GCP project
+resource "google_project_service" "enable_cspm_apis" {
+  // create a unique key per project and service to enable each API
+  for_each = { for item in local.project_and_services : "${item.project}-${item.service}" => item }
+
+  project = each.value.project
+  service = each.value.service
+  disable_on_destroy = false
+}
+
+# Output the projects and APIs enabled
+output "enabled_projects" {
+  value = distinct([for resource in google_project_service.enable_cspm_apis : resource.project])
+}
+
+output "enabled_services" {
+  value = distinct([for service in google_project_service.enable_cspm_apis : service.service])
+}

--- a/test/examples/organization_api_enablement/vm/main.tf
+++ b/test/examples/organization_api_enablement/vm/main.tf
@@ -1,0 +1,53 @@
+/*
+This terraform file is intended to enable the GCP APIs needed for VM feature within a GCP organization onboarding.
+It will create a google_project_service resource per each service enabled within each GCP project.
+The APIs needed for the VM feature are listed below:
+  - Compute Engine API
+
+* Note: This do not overwrite any other APIs config that your GCP project has, it will only enabled it if isn't yet.
+*/
+
+# Set local variables for Organization ID and API services to enable
+locals {
+  organizationID = "933620940614"
+  services = [
+    "compute.googleapis.com"
+  ]
+  project_and_services = flatten([
+    for project in data.google_projects.organization_projects.projects : [
+      for service in local.services : {
+        project = project.project_id
+        service = service
+      }
+    ]
+  ])
+}
+
+# GCP provider
+provider "google" {
+  region      = "us-west-1"
+}
+
+# Get list of projects under the specified organization
+data "google_projects" "organization_projects" {
+  filter = "parent.type:organization parent.id:${local.organizationID}"
+}
+
+# Enable API services for GCP project
+resource "google_project_service" "enable_vm_apis" {
+  // create a unique key per project and service to enable each API
+  for_each = { for item in local.project_and_services : "${item.project}-${item.service}" => item }
+
+  project = each.value.project
+  service = each.value.service
+  disable_on_destroy = false
+}
+
+# Output the projects and APIs enabled
+output "enabled_projects" {
+  value = distinct([for resource in google_project_service.enable_vm_apis : resource.project])
+}
+
+output "enabled_services" {
+  value = distinct([for service in google_project_service.enable_vm_apis : service.service])
+}

--- a/test/examples/single_api_enablement/cdr_ciem/main.tf
+++ b/test/examples/single_api_enablement/cdr_ciem/main.tf
@@ -1,0 +1,40 @@
+/*
+This terraform file is intended to enable the GCP APIs needed for CDR/CIEM feature within a single project onboarding.
+It will create a google_project_service resource per each service enabled within the GCP project.
+The APIs needed for the CDR/CIEM feature are listed below:
+  - Cloud Pub/Sub API
+
+* Note: This do not overwrite any other APIs config that your GCP project has, it will only enabled it if isn't yet.
+*/
+
+# Set local local variables for Project ID and API services to enable
+locals {
+  project = "org-child-project-1"
+  services = [
+    "pubsub.googleapis.com"
+  ]
+}
+
+# GCP provider
+provider "google" {
+  project     = local.project
+  region      = "us-west-1"
+}
+
+// Enable API services for GCP project
+resource "google_project_service" "enable_cdr_ciem_apis" {
+  project  = local.project
+
+  for_each = toset(local.services)
+  service = each.value
+  # TODO: Question? Leave a note to user that APIs will keep enabled when running a TF destroy here, makes sense?
+  disable_on_destroy = false
+}
+
+# Output the projects and APIs enabled
+output "enabled_projects" {
+  value = distinct([for service in local.services : google_project_service.enable_cdr_ciem_apis[service].project])
+}
+output "enabled_services" {
+  value = [for service in local.services : google_project_service.enable_cdr_ciem_apis[service].service]
+}

--- a/test/examples/single_api_enablement/cdr_ciem/main.tf
+++ b/test/examples/single_api_enablement/cdr_ciem/main.tf
@@ -27,7 +27,6 @@ resource "google_project_service" "enable_cdr_ciem_apis" {
 
   for_each = toset(local.services)
   service = each.value
-  # TODO: Question? Leave a note to user that APIs will keep enabled when running a TF destroy here, makes sense?
   disable_on_destroy = false
 }
 

--- a/test/examples/single_api_enablement/cspm/main.tf
+++ b/test/examples/single_api_enablement/cspm/main.tf
@@ -1,0 +1,56 @@
+/*
+This terraform file is intended to enable the GCP APIs needed for CSPM feature within a single project onboarding.
+It will create a google_project_service resource per each service enabled within the GCP project.
+The APIs needed for the CSPM feature are listed below:
+  - Security Token Service API
+  - Cloud Asset API
+  - Cloud Identity API
+  - Admin SDK API
+In addition, since CSPM is needed for onboard any GCP project these other APIs are also enabled:
+  - Identity and access management API
+  - IAM Service Account Credentials API
+  - Cloud Resource Manager API
+
+* Note: This do not overwrite any other APIs config that your GCP project has, it will only enabled it if isn't yet.
+*/
+
+# Set local variables for Project ID and API services to enable
+locals {
+  project = "org-child-project-1"
+  services = [
+    # CSPM specific APIs
+    "sts.googleapis.com",
+    "cloudasset.googleapis.com",
+    "cloudidentity.googleapis.com",
+    "admin.googleapis.com",
+
+    # additional APIs
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "cloudresourcemanager.googleapis.com"
+  ]
+}
+
+# GCP provider
+provider "google" {
+  project     = local.project
+  region      = "us-west-1"
+}
+
+// Enable API services for GCP project
+resource "google_project_service" "enable_cdr_ciem_apis" {
+  project  = local.project
+
+  for_each = toset(local.services)
+  service = each.value
+  # TODO: Question? Leave a note to user that APIs will keep enabled when running a TF destroy here, makes sense?
+  disable_on_destroy = false
+}
+
+# Output the projects and APIs enabled
+output "enabled_projects" {
+  value = distinct([for service in local.services : google_project_service.enable_cdr_ciem_apis[service].project])
+}
+output "enabled_services" {
+  value = [for service in local.services : google_project_service.enable_cdr_ciem_apis[service].service]
+}

--- a/test/examples/single_api_enablement/cspm/main.tf
+++ b/test/examples/single_api_enablement/cspm/main.tf
@@ -38,19 +38,18 @@ provider "google" {
 }
 
 // Enable API services for GCP project
-resource "google_project_service" "enable_cdr_ciem_apis" {
+resource "google_project_service" "enable_cspm_apis" {
   project  = local.project
 
   for_each = toset(local.services)
   service = each.value
-  # TODO: Question? Leave a note to user that APIs will keep enabled when running a TF destroy here, makes sense?
   disable_on_destroy = false
 }
 
 # Output the projects and APIs enabled
 output "enabled_projects" {
-  value = distinct([for service in local.services : google_project_service.enable_cdr_ciem_apis[service].project])
+  value = distinct([for service in local.services : google_project_service.enable_cspm_apis[service].project])
 }
 output "enabled_services" {
-  value = [for service in local.services : google_project_service.enable_cdr_ciem_apis[service].service]
+  value = [for service in local.services : google_project_service.enable_cspm_apis[service].service]
 }

--- a/test/examples/single_api_enablement/vm/main.tf
+++ b/test/examples/single_api_enablement/vm/main.tf
@@ -22,19 +22,18 @@ provider "google" {
 }
 
 // Enable API services for GCP project
-resource "google_project_service" "enable_cdr_ciem_apis" {
+resource "google_project_service" "enable_vm_apis" {
   project  = local.project
 
   for_each = toset(local.services)
   service = each.value
-  # TODO: Question? Leave a note to user that APIs will keep enabled when running a TF destroy here, makes sense?
   disable_on_destroy = false
 }
 
 # Output the projects and APIs enabled
 output "enabled_projects" {
-  value = distinct([for service in local.services : google_project_service.enable_cdr_ciem_apis[service].project])
+  value = distinct([for service in local.services : google_project_service.enable_vm_apis[service].project])
 }
 output "enabled_services" {
-  value = [for service in local.services : google_project_service.enable_cdr_ciem_apis[service].service]
+  value = [for service in local.services : google_project_service.enable_vm_apis[service].service]
 }

--- a/test/examples/single_api_enablement/vm/main.tf
+++ b/test/examples/single_api_enablement/vm/main.tf
@@ -1,0 +1,40 @@
+/*
+This terraform file is intended to enable the GCP APIs needed for VM feature within a single project onboarding.
+It will create a google_project_service resource per each service enabled within the GCP project.
+The APIs needed for the VM feature are listed below:
+  - Compute Engine API
+
+* Note: This do not overwrite any other APIs config that your GCP project has, it will only enabled it if isn't yet.
+*/
+
+# Set local variables for Project ID and API services to enable
+locals {
+  project = "org-child-project-1"
+  services = [
+    "compute.googleapis.com"
+  ]
+}
+
+# GCP provider
+provider "google" {
+  project     = local.project
+  region      = "us-west-1"
+}
+
+// Enable API services for GCP project
+resource "google_project_service" "enable_cdr_ciem_apis" {
+  project  = local.project
+
+  for_each = toset(local.services)
+  service = each.value
+  # TODO: Question? Leave a note to user that APIs will keep enabled when running a TF destroy here, makes sense?
+  disable_on_destroy = false
+}
+
+# Output the projects and APIs enabled
+output "enabled_projects" {
+  value = distinct([for service in local.services : google_project_service.enable_cdr_ciem_apis[service].project])
+}
+output "enabled_services" {
+  value = [for service in local.services : google_project_service.enable_cdr_ciem_apis[service].service]
+}


### PR DESCRIPTION
xref: https://sysdig.atlassian.net/browse/SSPROD-46145

This is a WIP for providing TF snippets to enable GCP APIs to customer so they don't have to do it manually.

All is working and the APIs are enabled properly for the GCP project and organization. The only thing that needs to be done is the scrapping of the folders within a GCP organization since the `google_projects` resource only provides the root projects within the organization and not the ones within folders, basically for a scenario like:
- MyOrg
    - MyProject1
    - MyProject2
    - MyFolder1
        - MyProject3
The `google_projects` resource is only retrieving the projects: `MyProject1` and `MyProject2`. In order to change this I'll need to use another resource that grabs the folders and create a recursive functionality to scrape all the Org - working on this already.