### PR TITLE
fix(onboarding): org dependency

### DIFF
--- a/modules/onboarding/organizational.tf
+++ b/modules/onboarding/organizational.tf
@@ -31,5 +31,8 @@ resource "sysdig_secure_organization" "google_organization" {
 
   management_account_id   = sysdig_secure_cloud_auth_account.google_account.id
   organizational_unit_ids = var.management_group_ids
-  depends_on              = [google_organization_iam_member.browser]
+  depends_on = [
+    google_organization_iam_member.browser,
+    sysdig_secure_cloud_auth_account.google_account
+  ]
 }


### PR DESCRIPTION
The implicit dependency organizations have on management accounts sets the apply/creation order correctly. However, the destroy order is not unwound in the reverse order.  Add explicit dependency to enforce this behavior.