### PR TITLE
fix(routing-key): enable routing key generation in a deterministic way

### DIFF
--- a/modules/integrations/pub-sub/main.tf
+++ b/modules/integrations/pub-sub/main.tf
@@ -29,10 +29,10 @@ data "sysdig_current_user" "user" {}
 # These locals indicate the suffix to create unique name for resources
 #-----------------------------------------------------------------------------------------
 locals {
-  suffix      = var.suffix == null ? random_id.suffix[0].hex : var.suffix
-  role_name   = "SysdigIngestionAuthRole"
-  key_name    = "${var.project_id}-${data.sysdig_current_user.user.id}"
-  routing_key = uuidv5("oid", local.key_name)
+  suffix        = var.suffix == null ? random_id.suffix[0].hex : var.suffix
+  role_name     = "SysdigIngestionAuthRole"
+  key_name      = "${var.project_id}-${data.sysdig_current_user.user.id}"
+  routing_key   = uuidv5("oid", local.key_name)
   ingestion_url = "${regex("^(.*)/[^/]+$", data.sysdig_secure_cloud_ingestion_assets.assets.gcp_metadata.ingestionURL)[0]}/${local.routing_key}"
 }
 

--- a/modules/integrations/pub-sub/main.tf
+++ b/modules/integrations/pub-sub/main.tf
@@ -22,14 +22,17 @@ data "google_project" "project" {
 
 data "sysdig_secure_tenant_external_id" "external_id" {}
 
-data "sysdig_secure_cloud_ingestion_assets" "assets" {}
+# data "sysdig_secure_cloud_ingestion_assets" "assets" {}
 
+data "sysdig_current_user" "user" {}
 #-----------------------------------------------------------------------------------------
 # These locals indicate the suffix to create unique name for resources
 #-----------------------------------------------------------------------------------------
 locals {
   suffix    = var.suffix == null ? random_id.suffix[0].hex : var.suffix
   role_name = "SysdigIngestionAuthRole"
+  key_name = "${var.project_id}-${data.sysdig_current_user.user.id}"
+  routing_key = uuidv5("oid", local.key_name)
 }
 
 
@@ -143,7 +146,8 @@ resource "google_pubsub_subscription" "ingestion_topic_push_subscription" {
   project                    = var.project_id
 
   push_config {
-    push_endpoint = data.sysdig_secure_cloud_ingestion_assets.assets.gcp_metadata.ingestionURL
+    push_endpoint = "https://app-staging.sysdigcloud.com/api/cloudingestion/gcp/v2/${local.routing_key}"
+#   push_endpoint = data.sysdig_secure_cloud_ingestion_assets.assets.gcp_metadata.ingestionURL
     attributes = {
       x-goog-version = "v1"
     }
@@ -256,7 +260,8 @@ resource "sysdig_secure_cloud_auth_account_component" "gcp_pubsub_datasource" {
         sink_name              = var.is_organizational ? google_logging_organization_sink.ingestion_sink[0].name : google_logging_project_sink.ingestion_sink[0].name
         push_subscription_name = google_pubsub_subscription.ingestion_topic_push_subscription.name
         push_endpoint          = google_pubsub_subscription.ingestion_topic_push_subscription.push_config[0].push_endpoint
-        routing_key            = data.sysdig_secure_cloud_ingestion_assets.assets.gcp_routing_key
+        routing_key            = local.routing_key
+#       routing_key            = data.sysdig_secure_cloud_ingestion_assets.assets.gcp_routing_key
       }
       service_principal = {
         workload_identity_federation = {

--- a/modules/integrations/pub-sub/main.tf
+++ b/modules/integrations/pub-sub/main.tf
@@ -29,9 +29,9 @@ data "sysdig_current_user" "user" {}
 # These locals indicate the suffix to create unique name for resources
 #-----------------------------------------------------------------------------------------
 locals {
-  suffix    = var.suffix == null ? random_id.suffix[0].hex : var.suffix
-  role_name = "SysdigIngestionAuthRole"
-  key_name = "${var.project_id}-${data.sysdig_current_user.user.id}"
+  suffix      = var.suffix == null ? random_id.suffix[0].hex : var.suffix
+  role_name   = "SysdigIngestionAuthRole"
+  key_name    = "${var.project_id}-${data.sysdig_current_user.user.id}"
   routing_key = uuidv5("oid", local.key_name)
 }
 
@@ -147,7 +147,7 @@ resource "google_pubsub_subscription" "ingestion_topic_push_subscription" {
 
   push_config {
     push_endpoint = "https://app-staging.sysdigcloud.com/api/cloudingestion/gcp/v2/${local.routing_key}"
-#   push_endpoint = data.sysdig_secure_cloud_ingestion_assets.assets.gcp_metadata.ingestionURL
+    #   push_endpoint = data.sysdig_secure_cloud_ingestion_assets.assets.gcp_metadata.ingestionURL
     attributes = {
       x-goog-version = "v1"
     }
@@ -261,7 +261,7 @@ resource "sysdig_secure_cloud_auth_account_component" "gcp_pubsub_datasource" {
         push_subscription_name = google_pubsub_subscription.ingestion_topic_push_subscription.name
         push_endpoint          = google_pubsub_subscription.ingestion_topic_push_subscription.push_config[0].push_endpoint
         routing_key            = local.routing_key
-#       routing_key            = data.sysdig_secure_cloud_ingestion_assets.assets.gcp_routing_key
+        #       routing_key            = data.sysdig_secure_cloud_ingestion_assets.assets.gcp_routing_key
       }
       service_principal = {
         workload_identity_federation = {

--- a/modules/integrations/pub-sub/main.tf
+++ b/modules/integrations/pub-sub/main.tf
@@ -24,18 +24,15 @@ data "sysdig_secure_tenant_external_id" "external_id" {}
 
 data "sysdig_secure_cloud_ingestion_assets" "assets" {}
 
-data "sysdig_current_user" "user" {}
 #-----------------------------------------------------------------------------------------
 # These locals indicate the suffix to create unique name for resources
 #-----------------------------------------------------------------------------------------
 locals {
   suffix        = var.suffix == null ? random_id.suffix[0].hex : var.suffix
   role_name     = "SysdigIngestionAuthRole"
-  key_name      = "${var.project_id}-${data.sysdig_current_user.user.id}"
-  routing_key   = uuidv5("oid", local.key_name)
+  routing_key   = random_uuid.routing_key.result
   ingestion_url = "${regex("^(.*)/[^/]+$", data.sysdig_secure_cloud_ingestion_assets.assets.gcp_metadata.ingestionURL)[0]}/${local.routing_key}"
 }
-
 
 #-----------------------------------------------------------------------------------------------------------------------
 # A random resource is used to generate unique Pub Sub name suffix for resources.
@@ -45,6 +42,12 @@ resource "random_id" "suffix" {
   count       = var.suffix == null ? 1 : 0
   byte_length = 3
 }
+
+
+#-----------------------------------------------------------------------------------------------------------------------
+# A random UUID is used to generate a unique identifier for the routing key per onboarded entity.
+#-----------------------------------------------------------------------------------------------------------------------
+resource "random_uuid" "routing_key" {}
 
 #-----------------------------------------------------------------------------------------
 # Audit Logs

--- a/modules/integrations/pub-sub/outputs.tf
+++ b/modules/integrations/pub-sub/outputs.tf
@@ -5,6 +5,6 @@ output "pubsub_datasource_component_id" {
 }
 
 output "pubsub_datasource_routing_key" {
-  value = local.routing_key
+  value       = local.routing_key
   description = "Component routing key identifier of Webhook Datasource"
 }

--- a/modules/integrations/pub-sub/outputs.tf
+++ b/modules/integrations/pub-sub/outputs.tf
@@ -3,8 +3,3 @@ output "pubsub_datasource_component_id" {
   description = "Component identifier of Webhook Datasource integration created in Sysdig Backend for Log Ingestion"
   depends_on  = [sysdig_secure_cloud_auth_account_component.gcp_pubsub_datasource]
 }
-
-output "pubsub_datasource_routing_key" {
-  value       = local.routing_key
-  description = "Component routing key identifier of Webhook Datasource"
-}

--- a/modules/integrations/pub-sub/outputs.tf
+++ b/modules/integrations/pub-sub/outputs.tf
@@ -3,3 +3,8 @@ output "pubsub_datasource_component_id" {
   description = "Component identifier of Webhook Datasource integration created in Sysdig Backend for Log Ingestion"
   depends_on  = [sysdig_secure_cloud_auth_account_component.gcp_pubsub_datasource]
 }
+
+output "pubsub_datasource_routing_key" {
+  value = local.routing_key
+  description = "Component routing key identifier of Webhook Datasource"
+}


### PR DESCRIPTION
xref: https://sysdig.atlassian.net/browse/SSPROD-47456

This PR changes how the `routingKey` value can be generated in a deterministic way based off the `customerID` and `projectID` using the [uuidv5](https://developer.hashicorp.com/terraform/language/functions/uuidv5) function within Terraform. This will help avoiding to update the routing key to be updated every time and also avoid leaking resources. 

It's always going to call the `UpsertRoutingKey` method when storing the component within `cloudauth` service.

`Note:` I was able to run a TF `APPLY` and then `RE-APPLY` it without updating the `routingKey` and without the subsequent errors. 