### PR TITLE
feat(project_sink): set project

### DIFF
--- a/modules/integrations/pub-sub/main.tf
+++ b/modules/integrations/pub-sub/main.tf
@@ -100,6 +100,7 @@ resource "google_pubsub_topic" "deadletter_topic" {
 resource "google_logging_project_sink" "ingestion_sink" {
   count       = var.is_organizational ? 0 : 1
   name        = "${google_pubsub_topic.ingestion_topic.name}_sink"
+  project     = var.project_id
   description = "Sysdig sink to direct the AuditLogs to the PubSub topic used for data gathering"
 
   # NOTE: The target destination is a PubSub topic


### PR DESCRIPTION
Explicitly specify the **project_id** when using the project installation method (as opposed to the organizational method). This is necessary if the GCP provider uses a different project.